### PR TITLE
[cmake] rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 2.6)
 #set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 #find_package(platform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(kodiplatform REQUIRED)


### PR DESCRIPTION
Ported from
https://github.com/notspiff/visualization.waveforhue/pull/3/commits/06598bd571df6b78ad42a5dbeabee2c1cdc12916

Package renaming is need after xbmc/xbmc#9750 goes in.

Signed-off-by: Bernd Kuhls bernd.kuhls@t-online.de
